### PR TITLE
feat: add support for structurizr diagrams

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -37,6 +37,7 @@ const DEFAULT_SETTINGS: KrokiSettings = {
         {prettyName: "Nomnoml", krokiBlockName: "nomnoml", obsidianBlockName: "nomnoml", description: "", url: "https://github.com/skanaar/nomnoml", enabled: true, toggle: null},
         {prettyName: "Pikchr", krokiBlockName: "pikchr", obsidianBlockName: "pikchr", description: "", url: "https://github.com/drhsqlite/pikchr", enabled: true, toggle: null},
         {prettyName: "PlantUML", krokiBlockName: "plantuml", obsidianBlockName: "plantuml", description: "", url: "https://github.com/plantuml/plantuml", enabled: false, toggle: null},
+        {prettyName: "Structurizr", krokiBlockName: "structurizr", obsidianBlockName: "/structurizr", description: "", url: "https://structurizr.com/", enabled: true, toggle: null},
         {prettyName: "Svgbob", krokiBlockName: "svgbob", obsidianBlockName: "svgbob", description: "", url: "https://github.com/ivanceras/svgbob", enabled: true, toggle: null},
         {prettyName: "UMlet", krokiBlockName: "umlet", obsidianBlockName: "umlet", description: "", url: "https://github.com/umlet/umlet", enabled: true, toggle: null},
         {prettyName: "Vega", krokiBlockName: "vega", obsidianBlockName: "vega", description: "", url: "https://github.com/vega/vega", enabled: true, toggle: null},


### PR DESCRIPTION
Kroki added structurizr support to the 0.16 release. This allows to define these diagrams in obsidian.