### PR TITLE
normalize URLs with trailing slash

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -144,7 +144,7 @@ class KrokiSettingsTab extends PluginSettingTab {
             .addText(text => text.setPlaceholder(DEFAULT_SETTINGS.server_url)
                 .setValue(this.plugin.settings.server_url)
                 .onChange(async (value) => {
-                        this.plugin.settings.server_url = value;
+                        this.plugin.settings.server_url = ensureTrailingSlash(value);
                         await this.plugin.saveSettings();
                     }
                 )
@@ -199,4 +199,11 @@ class KrokiSettingsTab extends PluginSettingTab {
             });
         }
     }
+}
+
+function ensureTrailingSlash(url: string) : string {
+    if (!url.endsWith('/')) {
+        return url + '/';
+    }
+    return url;
 }


### PR DESCRIPTION
Requests paths are built assuming the `server_url` has a trailing slash. When the trailing slash is not included with a custom URL, its troublesome to figure out why requests are not working. This PR ensures that it exists.

PS: Thanks for the great plugin