### PR TITLE
Include NodeJS builtin 'buffer' in rollup using rollup node pollyfills.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
 import { App, MarkdownPostProcessorContext, Plugin, PluginSettingTab, Setting, ToggleComponent, request } from 'obsidian';
+import { Buffer } from 'buffer';
 
 import * as pako from 'pako';
 

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/node": "^14.14.2",
+    "@types/pako": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.22.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+    "pako": "^1.0.10",
     "rollup": "^2.32.1",
+    "rollup-plugin-polyfill-node": "^0.13.0",
     "tslib": "^2.0.3",
-    "typescript": "^4.0.3",
-    "@types/pako": "^1.0.1",
-    "pako": "^1.0.10"
+    "typescript": "^4.0.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import typescript from '@rollup/plugin-typescript';
 import {nodeResolve} from '@rollup/plugin-node-resolve';
+import nodePolyfills from 'rollup-plugin-polyfill-node';
 import commonjs from '@rollup/plugin-commonjs';
 
 const banner = 
@@ -22,6 +23,7 @@ export default {
   plugins: [
     typescript(),
     nodeResolve({browser: true}),
+    nodePolyfills(),
     commonjs(),
   ]
 };


### PR DESCRIPTION
To solve [this issue](https://github.com/gregzuro/obsidian-kroki/issues/8). I have only been able to test this on my Galaxy Tab S8 but so far this fix seems functional and restores this plugins ability to embed images in the notes.